### PR TITLE
Ignore ssl errors

### DIFF
--- a/gitpillage.sh
+++ b/gitpillage.sh
@@ -50,9 +50,9 @@ function get {
     if [ ! -e .git/$1 ]; then
       echo "Getting $1"
       if [ "$CRAWLER" == 'wget' ]; then
-          wget $BASEURL$1 -x -nH --cut-dirs=$DIR_COUNT
+          wget $BASEURL$1 -x -nH --cut-dirs=$DIR_COUNT --no-check-certificate
       else
-          curl $BASEURL$1 -s -f -S --create-dirs -o .git/$1
+          curl $BASEURL$1 -s -f -S --create-dirs -o .git/$1 --insecure
       fi
     fi
 }


### PR DESCRIPTION
When the remote server's ssl cert is incorrect or insecure so that wget and curl will not connect to it, these flags will ignore the ssl warnings and connect anyway.

My only concern with these flags is that they are hardcoded. It may be worth adding this as an optional flag passed to the script.
